### PR TITLE
Fix check that issuer or account name don't contain a colon

### DIFF
--- a/src/Secret.php
+++ b/src/Secret.php
@@ -17,7 +17,7 @@ class Secret
     public function __construct($issuer, $accountName, $secretKey)
     {
         // As per spec sheet
-        if (strpos($this->issuer.$this->accountName, ":")!==false) {
+        if (strpos($issuer.$accountName, ":")!==false) {
             throw new \InvalidArgumentException("Neither the 'Issuer' parameter nor the 'AccountName' parameter may contain a colon");
         }
 


### PR DESCRIPTION
The properties `$this->issuer` and `$this->accountName` are always `null` that the time they were checked because they haven't been initialized yet. We should check the parameters instead.