### PR TITLE
Update chaining of methods: setWriterByName

### DIFF
--- a/src/QrImageGenerator/EndroidQrImageGenerator.php
+++ b/src/QrImageGenerator/EndroidQrImageGenerator.php
@@ -23,6 +23,7 @@ class EndroidQrImageGenerator implements QrImageGeneratorInterface
         $qrCode = new QrCode($secret->getUri());
         $qrCode->setSize($this->size);
 
-        return $qrCode->setWriterByName('png')->writeDataUri();
+        $qrCode->setWriterByName('png');
+        return $qrCode->writeDataUri();
     }
 }


### PR DESCRIPTION
setWriterByName does not return $this, so it cannot be chained. By seperating the two, qr codes can be created again.