### PR TITLE
Allow composer to install this bundle for symfony 3.4 and php7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "Christian-Riesen/base32": "^1.2",
         "psr/cache": "^1.0",
-        "paragonie/random_compat": "^2.0"
+        "paragonie/random_compat": "^2.0|~9.99"
     },
     "require-dev": {
         "phpunit/phpunit": "~6",


### PR DESCRIPTION
Taken from https://github.com/symfony/polyfill-php70/commit/eecb388ec0f7e949747cc919458c9b990dd1c319
Fixes https://github.com/Dolondro/google-authenticator/issues/24