### PR TITLE
Proper usage of time slices

### DIFF
--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -16,6 +16,18 @@ class GoogleAuthenticator
      */
     protected $cachePool = null;
 
+    private $time;
+
+    /**
+     * GoogleAuthenticator constructor.
+     *
+     * @param $time
+     */
+    public function __construct($time = null)
+    {
+        $this->time = $time ? $time : time();
+    }
+
     /**
      * @param CacheItemPoolInterface $cacheItemPoolInterface
      */
@@ -82,7 +94,7 @@ class GoogleAuthenticator
 
     protected function getTimeSlice($offset = 0)
     {
-        return floor(time() / 30) + ($offset * 30);
+        return floor($this->time / 30) + $offset;
     }
 
     /**

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -25,7 +25,7 @@ class GoogleAuthenticator
      */
     public function __construct($time = null)
     {
-        $this->time = $time ? $time : time();
+        $this->time = $time;
     }
 
     /**
@@ -94,7 +94,7 @@ class GoogleAuthenticator
 
     protected function getTimeSlice($offset = 0)
     {
-        return floor($this->time / 30) + $offset;
+        return floor($this->getTime() / 30) + $offset;
     }
 
     /**
@@ -136,5 +136,14 @@ class GoogleAuthenticator
 
         // Finally, pad out the string with 0s
         return str_pad($value % $modulo, $this->codeLength, '0', STR_PAD_LEFT);
+    }
+
+    private function getTime()
+    {
+        if (!$this->time) {
+            $this->time = time();
+        }
+
+        return $this->time;
     }
 }

--- a/tests/Authenticator/AuthenticatorTest.php
+++ b/tests/Authenticator/AuthenticatorTest.php
@@ -7,10 +7,36 @@ use PHPUnit\Framework\TestCase;
 
 class AuthenticatorTest extends TestCase
 {
+    const SECRET = "G2XLNTQRVES7JF3V";
+
+    const CODE = "081446";
+
+    const TIME = 1456073370;
+
     public function testCalculateCode()
     {
         $authenticator = new GoogleAuthenticator();
-        $this->assertEquals("081446", $authenticator->calculateCode("G2XLNTQRVES7JF3V", 48535779));
+        $this->assertEquals(self::CODE, $authenticator->calculateCode(self::SECRET, self::TIME / 30));
         $this->assertEquals("818888", $authenticator->calculateCode("OX35UDZUWP23WBUA", 48535782));
+    }
+
+    public function testAuthenticate()
+    {
+        $authenticator = new GoogleAuthenticator(self::TIME);
+        self::assertTrue($authenticator->authenticate(self::SECRET, self::CODE));
+
+        // user is 30 seconds ahead
+        $authenticator = new GoogleAuthenticator(self::TIME - 30);
+        self::assertTrue($authenticator->authenticate(self::SECRET, self::CODE));
+
+        // user is 59 seconds before, so we test for a newer code
+        $authenticator = new GoogleAuthenticator(self::TIME + 59);
+        self::assertTrue($authenticator->authenticate(self::SECRET, self::CODE));
+
+        $authenticator = new GoogleAuthenticator(self::TIME - 31);
+        self::assertFalse($authenticator->authenticate(self::SECRET, self::CODE));
+
+        $authenticator = new GoogleAuthenticator(self::TIME + 60);
+        self::assertFalse($authenticator->authenticate(self::SECRET, self::CODE));
     }
 }


### PR DESCRIPTION
Because of a wrong usage of `getTimeSlice` users can not use previous code and must enter and validate within 30 seconds, which is sometimes tedious.