### PR TITLE
Use hash equals in order to prevent time side-channel attack

### DIFF
--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -62,6 +62,7 @@ class GoogleAuthenticator
             $calculatedCode = $this->calculateCode($secret, $timeSlice);
             if ($this->isEqualCode($calculatedCode, $code)) {
                 $isCodeEqual = true;
+
                 break;
             }
         }
@@ -143,6 +144,7 @@ class GoogleAuthenticator
     {
         $length1 = substr_count($code1 ^ $code2, "\0") * 2;
         $length2 = strlen($code1.$code2);
+
         return hash_equals($length1, $length2);
     }
 

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -146,7 +146,7 @@ class GoogleAuthenticator
     protected function isEqual($string1, $string2)
     {
         // Use hash equals in order to prevent time side-channel attack
-        return hash_equals(substr_count($string1 ^ $string2, "\0") * 2,  strlen($string1.$string2));
+        return hash_equals(substr_count($string1 ^ $string2, "\0") * 2, strlen($string1.$string2));
     }
 
     /**

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -145,7 +145,8 @@ class GoogleAuthenticator
      */
     protected function isEqual($string1, $string2)
     {
-        return substr_count($string1 ^ $string2, "\0") * 2 === strlen($string1.$string2);
+        // Use hash equals in order to prevent time side-channel attack
+        return hash_equals(substr_count($string1 ^ $string2, "\0") * 2,  strlen($string1.$string2));
     }
 
     /**


### PR DESCRIPTION
String compare is not secure since one can perform a side-channel attack. In order to prevent this, we should use hash_equals, which does a time attack safe comparison.