### PR TITLE
3.0.0 : Update for php8.2 and psr/cache:3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,1 @@
-/tests              export-ignore
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/phpunit.xml        export-ignore
-/example.php	    export-ignore
+/.github    export-ignore

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -1,0 +1,26 @@
+name: Autotest
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: php:8.2-cli-alpine
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Vendor
+        run: wget https://getcomposer.org/download/latest-stable/composer.phar && php composer.phar i
+
+      - name: Run PHPSTAN
+        run: php composer.phar phpstan
+
+      - name: Run CodeStyle check
+        run: php composer.phar cs-check
+
+      - name: PhpUnit
+        run: php composer.phar phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.idea/
 /composer.lock
 /example.html
+/composer.phar
+/tests/file.cache
+/tests/.phpcs-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.0] - 2025-03-26
+### Added
+- Support PHP 8.2
+- Update all libs (endroid/qr-code, psr/cache, christian-riesen/base32, paragonie/random_compat)
+- Add psr/simple-cache:^3.0
+- Add CodeStyle fixer
+- PhpStan level up to 8
+- Add fast command with `Makeile` 
+- Use Docker
+
 ## [2.2.0] - 2021-05-24
 ### Added
 - Support for different types of writer for Endroid

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+SHELL = /bin/bash
+### https://makefiletutorial.com/
+
+docker := docker run -it --rm -v $(PWD):/app -w /app php:8.2-cli-alpine
+composer := $(docker) php composer.phar
+
+bash:
+	$(docker) bash
+
+composer-download:
+	test -f composer.phar || wget https://getcomposer.org/download/latest-stable/composer.phar
+
+composer-i:
+	@make composer-download
+	$(composer) install --prefer-dist --no-scripts
+
+composer-u:
+	$(composer) update --prefer-dist --no-scripts $(name)
+
+cs-fix:
+	$(composer) cs-fix
+
+cs-check:
+	$(composer) cs-check
+
+phpstan:
+	$(composer) phpstan
+
+phpunit:
+	$(composer) phpunit
+
+test:
+	$(composer) cs-check
+	$(composer) phpstan
+	$(composer) phpunit

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This gives you a secret. You should:
 2. attach the secret to their user account so you can query it
 
 There are 2 ImageGenerator implementations included with this library:
-1. EndroidQrImageGenerator which requires you composer require `endroid/qr-code:~2.2|~3` which generates it without any external service dependencies.
+1. EndroidQrImageGenerator which requires you composer require `endroid/qr-code:^6.0` which generates it without any external service dependencies.
 2. GoogleImageGenerator which uses the Google QR code API to generate the image.
 
 I'd recommend using Endroid as it seems that Google has now [deprecated their QR code API](https://developers.google.com/chart/infographics/docs/qr_codes)

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "xakki/google-authenticator",
+    "name": "dochne/google-authenticator",
     "description": "Code to authenticate against the Google Authenticator app",
     "license": "MIT",
     "version": "3.0.0",

--- a/composer.json
+++ b/composer.json
@@ -1,25 +1,32 @@
 {
-    "name": "dolondro/google-authenticator",
+    "name": "xakki/google-authenticator",
     "description": "Code to authenticate against the Google Authenticator app",
     "license": "MIT",
+    "version": "3.0.0",
     "authors": [
         {
             "name": "Doug Nelson",
             "email": "dougnelson@silktide.com"
+        },
+        {
+            "name": "Xakki",
+            "email": "git@xakki.ru"
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "christian-riesen/base32": "^1.2",
-        "psr/cache": "^1.0",
-        "paragonie/random_compat": "^2.0|~9.99"
+        "php": ">=8.2",
+        "christian-riesen/base32": "^1.6",
+        "psr/cache": "^3.0",
+        "psr/simple-cache": "^3.0",
+        "paragonie/random_compat": "^9.99"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6",
-        "endroid/qr-code": "~2.2|~3",
-        "cache/filesystem-adapter": "^1.0",
-        "phpstan/phpstan": "^0.11.3",
-        "cache/array-adapter": "^1.0"
+        "phpunit/phpunit": "^11",
+        "endroid/qr-code": "^6.0",
+        "phpstan/phpstan": "^2.1",
+        "symfony/cache": "^7.2",
+        "squizlabs/php_codesniffer": "*",
+        "opsway/psr12-strict-coding-standard": "*"
     },
     "suggests": {
         "endroid/qr-code": "Allows use of EndroidQrImageGenerator to generate the QR code images"
@@ -33,5 +40,16 @@
         "psr-4": {
             "Dolondro\\GoogleAuthenticator\\Tests\\": "tests"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
+    "scripts": {
+        "phpstan": "XDEBUG_MODE=off vendor/bin/phpstan analyse",
+        "cs-check": "XDEBUG_MODE=off vendor/bin/phpcs",
+        "cs-fix": "XDEBUG_MODE=off vendor/bin/phpcbf",
+        "phpunit": "XDEBUG_MODE=off vendor/bin/phpunit -c phpunit.xml --no-coverage"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,302 @@
+<?xml version="1.0"?>
+<ruleset name="StrictPSR12" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+    <description>Strict PSR12 code style standard</description>
+
+    <arg name="tab-width" value="4"/>
+    <arg name="basepath" value="."/>
+    <arg name="cache" value="tests/.phpcs-cache"/>
+    <arg name="colors"/>
+
+    <file>src/</file>
+    <file>tests/</file>
+    <exclude-pattern>vendor/*</exclude-pattern>
+
+    <rule ref="PSR12">
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
+        <exclude name="PSR12.Functions.ReturnTypeDeclaration"/>
+    </rule>
+
+    <rule ref="Generic.Files.LineLength">
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+    </rule>
+
+    <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag"/>
+    <rule ref="Generic.PHP.DisallowShortOpenTag">
+        <exclude name="Generic.PHP.DisallowShortOpenTag.EchoFound"/>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
+    <rule ref="WebimpressCodingStandard.WhiteSpace.BlankLine"/>
+    <rule ref="WebimpressCodingStandard.WhiteSpace.BraceBlankLine"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="spacing" value="1"/>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="WebimpressCodingStandard.Strings.NoConcatenationAtTheEnd"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <!-- But multiline is useful for readability -->
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
+    <!-- The short array syntax MUST be used to define arrays. -->
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <!-- All values in multiline arrays must be indented with 4 spaces. -->
+    <rule ref="Generic.Arrays.ArrayIndent"/>
+    <rule ref="WebimpressCodingStandard.Arrays.TrailingArrayComma"/>
+    <rule ref="WebimpressCodingStandard.Arrays.Format"/>
+    <!--    <rule ref="SlevomatCodingStandard.PHP.ShortList"/>-->
+    <rule ref="WebimpressCodingStandard.WhiteSpace.Namespace"/>
+    <!--    &lt;!&ndash; There MAY NOT be a space around a namespace separator. &ndash;&gt;-->
+    <rule ref="WebimpressCodingStandard.WhiteSpace.NamespaceSeparator"/>
+    <!--    &lt;!&ndash; Import statements MUST be alphabetically sorted. &ndash;&gt;-->
+    <rule ref="WebimpressCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+    <!-- Functions and const keywords MUST be lowercase in import statements. -->
+    <rule ref="WebimpressCodingStandard.Namespaces.ConstAndFunctionKeywords"/>
+    <!--    &lt;!&ndash; Unused import statements MUST be removed.&ndash;&gt;-->
+    <rule ref="WebimpressCodingStandard.Namespaces.UnusedUseStatement">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+    <!--    &lt;!&ndash; Superfluous leading backslash in import statements MUST be removed. &ndash;&gt;-->
+    <rule ref="WebimpressCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
+    <!--    &lt;!&ndash; Fancy group import statements MUST NOT be used. &ndash;&gt;-->
+    <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
+    <!--    &lt;!&ndash; Each import statement MUST be on its own line. &ndash;&gt;-->
+    <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
+    <!--    &lt;!&ndash; Import statements must be grouped (classes, functions, constants) and-->
+    <!--         MUST be separated by empty lines. &ndash;&gt;-->
+    <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
+    <!--    &lt;!&ndash; Import statements aliases for classes, traits, functions and constants-->
+    <!--         MUST be useful. &ndash;&gt;-->
+    <rule ref="WebimpressCodingStandard.Namespaces.RedundantAlias"/>
+    <rule ref="Squiz.Scope.StaticThisUsage"/>
+    <!-- Returned variables SHOULD be useful and SHOULD NOT be assigned to a value
+         and returned on the next line. -->
+    <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
+
+    <rule ref="WebimpressCodingStandard.WhiteSpace.CommaSpacing"/>
+    <rule ref="WebimpressCodingStandard.Formatting.NoSpaceAfterSplat"/>
+    <rule ref="WebimpressCodingStandard.Formatting.Reference"/>
+
+    <!-- The question mark MUST be used when the default argument value is null. -->
+    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+
+    <!-- The final keyword on methods MUST be omitted in final classes. -->
+    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
+
+    <!-- There SHOULD be one single space after `break` and `continue` structures with
+         a numeric argument argument. -->
+    <rule ref="WebimpressCodingStandard.ControlStructures.BreakAndContinue"/>
+    <!-- Statements MUST NOT be empty, except for catch statements. -->
+    <rule ref="Generic.CodeAnalysis.EmptyStatement">
+        <!-- But allow empty catch -->
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/>
+    </rule>
+
+    <!-- The `continue` control structure MUST NOT be used in switch statements,
+         `break` SHOULD be used instead. -->
+    <rule ref="WebimpressCodingStandard.ControlStructures.ContinueInSwitch"/>
+
+    <!-- All catch blocks MUST be reachable. -->
+    <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
+
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+
+    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
+
+    <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
+
+    <rule ref="WebimpressCodingStandard.Functions.Param">
+        <exclude name="WebimpressCodingStandard.Functions.Param.MissingSpecification"/>
+        <exclude name="WebimpressCodingStandard.Functions.Param.RedundantParamDoc"/>
+    </rule>
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType">
+        <exclude name="WebimpressCodingStandard.Functions.ReturnType.ReturnValue"/>
+        <exclude name="WebimpressCodingStandard.Functions.ReturnType.RedundantReturnDoc"/>
+    </rule>
+
+    <rule ref="Squiz.Commenting.DocCommentAlignment">
+        <exclude name="Squiz.Commenting.DocCommentAlignment.SpaceAfterStar"/>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
+        <properties>
+            <property name="linesCountBeforeFirstContent" value="0"/>
+            <property name="linesCountAfterLastContent" value="0"/>
+            <property name="linesCountBetweenDescriptionAndAnnotations" value="1"/>
+            <property name="linesCountBetweenAnnotationsGroups" value="1"/>
+            <property name="annotationsGroups" type="array">
+                <element value="
+                        @internal,
+                        @deprecated
+                    "/>
+                <element value="
+                        @link,
+                        @uses,
+                        @see,
+                        @copyright,
+                        @license
+                    "/>
+                <element value="
+                        @ORM\,
+                        @ODM\,
+                        @PHPCR\,
+                        @OA\
+                    "/>
+                <element value="
+                        @param\,
+                        @return\,
+                        @throws\
+                    "/>
+            </property>
+        </properties>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
+        <properties>
+            <property name="forbiddenAnnotations" type="array">
+                <element value="@category"/>
+                <element value="@created"/>
+                <element value="@package"/>
+                <element value="@subpackage"/>
+                <element value="@expectedException"/>
+                <element value="@expectedExceptionCode"/>
+                <element value="@expectedExceptionMessage"/>
+                <element value="@expectedExceptionMessageRegExp"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- The words _private_, _protected_, _static_, _constructor_, _deconstructor_,
+         _Created by_, _getter_ and _setter_, MUST NOT be used in comments. -->
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
+        <properties>
+            <property name="forbiddenCommentPatterns" type="array">
+                <element value="~^(?:(?!private|protected|static)\S+ )?(?:con|de)structor\.\z~i"/>
+                <element value="~^Created by .+\.\z~i"/>
+                <element value="~^(User|Date|Time): \S+\z~i"/>
+                <element value="~^\S+ [gs]etter\.\z~i"/>
+                <element value="~^Class \S+\z~i"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Heredoc and nowdoc tags MUST be uppercase without spaces. -->
+    <rule ref="WebimpressCodingStandard.Formatting.Heredoc"/>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
+        <properties>
+            <property name="spacesCountBeforeColon" value="0"/>
+        </properties>
+    </rule>
+    <rule ref="Generic.WhiteSpace.ScopeIndent"/>
+    <rule ref="PSR2.Methods.FunctionCallSignature.Indent"/>
+    <rule ref="PSR2.Methods.FunctionCallSignature.OpeningIndent"/>
+    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace.Indent"/>
+
+    <!-- Variable names MUST be declared in camelCase. -->
+    <rule ref="WebimpressCodingStandard.NamingConventions.ValidVariableName"/>
+
+    <!-- Property name "$_rateTime" should not be prefixed with an underscore to indicate visibility -->
+    <rule ref="PSR2.Classes.PropertyDeclaration.Underscore"/>
+
+    <!-- Visibility must be declared on all constants if your project supports PHP 7.1 or later -->
+    <rule ref="PSR12.Properties.ConstantVisibility.NotFound"/>
+
+    <!-- Return type is "self" so return tag must be one of: "self", "static" or "$this" -->
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType.ReturnArray"/>
+
+    <!-- Return type in PHPDoc tag is different than declared type in method declaration: "mixed" and "string" -->
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType.DifferentTagAndDeclaration"/>
+
+    <!-- Unexpected type "string" found in return tag -->
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType.ReturnComplexType"/>
+
+    <!-- Function return type is array nor iterable, but function returns array here -->
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType.ReturnArray"/>
+    <!-- Function returns only array, but return type contains not array types: false -->
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType.ReturnArrayOnly"/>
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType.ReturnSelf"/>
+
+    <!-- Function returns only new instance of PaymentRouteResult, but return type is not only PaymentRouteResult -->
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType.ReturnNewInstanceOnly"/>
+
+    <!-- Return type contains "mixed" which is not an array type -->
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType.NotArrayType"/>
+
+    <!-- Return type of "getDefaultPaymentRouteResult" function is not void, but function has no return statement -->
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType.InvalidNoReturn"/>
+
+    <!-- Invalid type "string" for parameter $merchantValidationForm -->
+    <rule ref="WebimpressCodingStandard.Functions.Param.ParamDocInvalidType">
+    </rule>
+
+    <!-- Parameter $form has not been found in function declaration -->
+    <rule ref="WebimpressCodingStandard.Functions.Param">
+        <exclude-pattern>src/Db.php</exclude-pattern>
+    </rule>
+
+    <!-- String concat is not required here; use a single string instead -->
+    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+
+    <!-- Function returns only boolean true, but return type is not only true -->
+    <rule ref="WebimpressCodingStandard.Functions.ReturnType">
+        <exclude-pattern>src/Db.php</exclude-pattern>
+    </rule>
+
+    <!-- Arguments with default values must be at the end of the argument list -->
+    <rule ref="PEAR.Functions.ValidDefaultValue"/>
+
+    <!-- Closing brace of array declaration must be on a new line -->
+    <rule ref="Generic.Arrays.ArrayIndent.CloseBraceNotNewLine"/>
+
+    <!-- Multi-line arrays must have a trailing comma after the last element -->
+    <rule ref="WebimpressCodingStandard.Arrays.TrailingArrayComma.MissingTrailingComma"/>
+
+    <!-- String "kartik\grid\Module" contains class reference, use ::class instead -->
+    <rule ref="WebimpressCodingStandard.Formatting.StringClassReference"/>
+
+    <!-- A double colon must not be followed by a whitespace -->
+    <rule ref="WebimpressCodingStandard.Formatting.DoubleColon"/>
+
+    <!-- Parentheses around expression "self::LIST_TYPE_ACTIVE" are redundant -->
+    <rule ref="WebimpressCodingStandard.Formatting.RedundantParentheses"/>
+
+    <!-- There must be exactly 1 space(s) between the closing parenthesis and the colon when declaring a return type for a function -->
+    <rule ref="WebimpressCodingStandard.Formatting.ReturnType.SpacesBeforeColon">
+        <exclude name="WebimpressCodingStandard.Formatting.ReturnType.SpacesBeforeColon"/>
+    </rule>
+
+    <!-- There must be one array element per line -->
+    <rule ref="WebimpressCodingStandard.Arrays.Format"/>
+    <!-- Unexpected space after reference character -->
+    <rule ref="WebimpressCodingStandard.Formatting"/>
+
+    <rule ref="PSR1.Files.SideEffects"/>
+
+    <!-- Ignore for migrations. -->
+    <!-- Ignore missing namespace for migrations -->
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+    </rule>
+    <!-- Ignore camel caps format for class name of migrations -->
+    <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+    </rule>
+    <!-- Ignore no camel caps format for methods name -->
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+
+    </rule>
+
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols"/>
+    <!-- File appears to be minified and cannot be processed -->
+    <exclude-pattern>*.js</exclude-pattern>
+    <exclude-pattern>*.css</exclude-pattern>
+    <exclude-pattern>*.json</exclude-pattern>
+
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 8
+    paths:
+    	- src
+    	- tests

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,36 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<phpunit bootstrap="./vendor/autoload.php">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnNotice="true"
+         failOnWarning="true"
+         failOnDeprecation="true"
+         failOnPhpunitDeprecation="true"
+         stopOnError="true"
+         stopOnFailure="true"
+         testdox="true"
+         displayDetailsOnIncompleteTests="true"
+         displayDetailsOnSkippedTests="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         cacheResult="false"
+>
     <testsuites>
-        <testsuite name="Tests">
-            <directory suffix=".php">tests</directory>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-        </whitelist>
-        <blacklist>
-            <directory>./vendor</directory>
-        </blacklist>
-    </filter>
+    <coverage/>
+    <php>
+        <const name="PHPUNIT_INIT" value="true"/>
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/QrImageGenerator/GoogleQrImageGenerator.php
+++ b/src/QrImageGenerator/GoogleQrImageGenerator.php
@@ -6,21 +6,12 @@ use Dolondro\GoogleAuthenticator\Secret;
 
 class GoogleQrImageGenerator implements QrImageGeneratorInterface
 {
-    protected $width;
-    protected $height;
-
-    public function __construct($width = 200, $height = 200)
+    public function __construct(protected int $width = 200, protected int $height = 200)
     {
-        if (!is_numeric($width) || !is_numeric($height)) {
-            throw new \InvalidArgumentException("Both width and height are required to be numeric");
-        }
-
-        $this->width = $width;
-        $this->height = $height;
     }
 
-    public function generateUri(Secret $secret)
+    public function generateUri(Secret $secret): string
     {
-        return "https://chart.googleapis.com/chart?chs={$this->width}x{$this->height}&chld=M|0&cht=qr&chl=".$secret->getUri();
+        return "https://chart.googleapis.com/chart?chs={$this->width}x{$this->height}&chld=M|0&cht=qr&chl=" . $secret->getUri();
     }
 }

--- a/src/QrImageGenerator/QrImageGeneratorInterface.php
+++ b/src/QrImageGenerator/QrImageGeneratorInterface.php
@@ -6,5 +6,5 @@ use Dolondro\GoogleAuthenticator\Secret;
 
 interface QrImageGeneratorInterface
 {
-    public function generateUri(Secret $secret);
+    public function generateUri(Secret $secret): string;
 }

--- a/src/Secret.php
+++ b/src/Secret.php
@@ -4,65 +4,35 @@ namespace Dolondro\GoogleAuthenticator;
 
 class Secret
 {
-    protected $issuer;
-    protected $accountName;
-    protected $secretKey;
-
-    /**
-     * Secret constructor.
-     *
-     * @param string $issuer
-     * @param string $accountName
-     * @param string $secretKey
-     */
-    public function __construct($issuer, $accountName, $secretKey)
+    public function __construct(protected string $issuer, protected string $accountName, protected string $secretKey)
     {
         // As per spec sheet
-        if (strpos($issuer.$accountName, ":") !== false) {
+        if (str_contains($issuer . $accountName, ":")) {
             throw new \InvalidArgumentException("Neither the 'Issuer' parameter nor the 'AccountName' parameter may contain a colon");
         }
-
-        $this->issuer = $issuer;
-        $this->accountName = $accountName;
-        $this->secretKey = $secretKey;
     }
 
-    /**
-     * @return string
-     */
-    public function getUri()
+    public function getUri(): string
     {
-        return "otpauth://totp/".rawurlencode($this->getLabel())."?secret=".$this->getSecretKey()."&issuer=".rawurlencode($this->getIssuer());
+        return "otpauth://totp/" . rawurlencode($this->getLabel()) . "?secret=" . $this->getSecretKey() . "&issuer=" . rawurlencode($this->getIssuer());
     }
 
-    /**
-     * @return string
-     */
-    public function getLabel()
+    public function getLabel(): string
     {
-        return $this->issuer.":".$this->accountName;
+        return $this->issuer . ":" . $this->accountName;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getIssuer()
+    public function getIssuer(): string
     {
         return $this->issuer;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getAccountName()
+    public function getAccountName(): string
     {
         return $this->accountName;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getSecretKey()
+    public function getSecretKey(): string
     {
         return $this->secretKey;
     }

--- a/src/SecretFactory.php
+++ b/src/SecretFactory.php
@@ -4,15 +4,15 @@ namespace Dolondro\GoogleAuthenticator;
 
 class SecretFactory
 {
-    protected $secretLength;
+    protected int $secretLength;
 
     // For some reason the maniac who came up with base32 encoding decided they hated 0 and 1...
-    protected $base32Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    protected string $base32Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
     /**
      * @param int $secretLength - this is the length of the encoded string, as such, it must be divisible by 8
      */
-    public function __construct($secretLength = 16)
+    public function __construct(int $secretLength = 16)
     {
         if ($secretLength == 0 || $secretLength % 8 > 0) {
             throw new \InvalidArgumentException("Secret length must be longer than 0 and divisible by 8");
@@ -23,13 +23,8 @@ class SecretFactory
     /**
      * The spec technically allows you to only have an accountName not an issuer, but as it's strongly recommended,
      * I don't feel particularly guilty about forcing it in the create.
-     *
-     * @param string $issuer
-     * @param string $accountName
-     *
-     * @return Secret
      */
-    public function create($issuer, $accountName)
+    public function create(string $issuer, string $accountName): Secret
     {
         return new Secret($issuer, $accountName, $this->generateSecretKey());
     }
@@ -40,7 +35,7 @@ class SecretFactory
      * Interestingly, the easiest way to get truly random key is just to iterate through the base 32 chars picking random
      * characters
      */
-    public function generateSecretKey()
+    public function generateSecretKey(): string
     {
         $key = "";
         while (strlen($key) < $this->secretLength) {

--- a/tests/Authenticator/AuthenticatorTest.php
+++ b/tests/Authenticator/AuthenticatorTest.php
@@ -2,14 +2,15 @@
 
 namespace Dolondro\GoogleAuthenticator\Tests\Authenticator;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use Dolondro\GoogleAuthenticator\GoogleAuthenticator;
 use Dolondro\GoogleAuthenticator\Tests\Helper\ArrayPsr16Cache;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
 class AuthenticatorTest extends TestCase
 {
-    public function testCalculateCode()
+    public function testCalculateCode(): void
     {
         $authenticator = new GoogleAuthenticator();
         $this->assertEquals("818888", $authenticator->calculateCode("OX35UDZUWP23WBUA", 48535782));
@@ -27,10 +28,9 @@ class AuthenticatorTest extends TestCase
      *              [60, 2, true]
      *              [-31, 1, false]
      *              [-59, 2, true]
-     *
      * @throws \Psr\Cache\InvalidArgumentException
      */
-    public function testAuthenticate($timeOffset, $window, $success)
+    public function testAuthenticate(int $timeOffset, int $window, bool $success): void
     {
         $secret = "G2XLNTQRVES7JF3V";
         $code = "081446";
@@ -45,19 +45,22 @@ class AuthenticatorTest extends TestCase
         self::assertSame($success, $authenticator->authenticate($secret, $code));
     }
 
-    public function testReplayAttackPsr6()
+    public function testReplayAttackPsr6(): void
     {
         $secret = "G2XLNTQRVES7JF3V";
         $code = "081446";
         $time = 1456073370;
         $options = ["time" => $time];
         $authenticator = new GoogleAuthenticator($options);
-        $authenticator->setCache(new ArrayCachePool());
+        $authenticator->setCache(new PhpArrayAdapter(
+            __DIR__ . '/../file.cache',
+            new FilesystemAdapter(),
+        ));
         $this->assertTrue($authenticator->authenticate($secret, $code));
         $this->assertFalse($authenticator->authenticate($secret, $code));
     }
 
-    public function testReplayAttackPsr16()
+    public function testReplayAttackPsr16(): void
     {
         $secret = "G2XLNTQRVES7JF3V";
         $code = "081446";
@@ -67,14 +70,5 @@ class AuthenticatorTest extends TestCase
         $authenticator->setCache(new ArrayPsr16Cache());
         $this->assertTrue($authenticator->authenticate($secret, $code));
         $this->assertFalse($authenticator->authenticate($secret, $code));
-    }
-
-    /**
-     * @expectedException \Exception
-     */
-    public function testIncorrectCacheSupplied()
-    {
-        $authenticator = new GoogleAuthenticator();
-        $authenticator->setCache(new \DateTime());
     }
 }

--- a/tests/Helper/ArrayPsr16Cache.php
+++ b/tests/Helper/ArrayPsr16Cache.php
@@ -5,50 +5,68 @@ namespace Dolondro\GoogleAuthenticator\Tests\Helper;
 use Psr\SimpleCache\CacheInterface;
 
 /**
- * Class ArrayPsr16
  * A very half arsed incorrect implementation as it's really just to prove a point.
  */
 class ArrayPsr16Cache implements CacheInterface
 {
-    protected $data = [];
+    /** @var mixed[] */
+    protected array $data = [];
 
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
-        return isset($this->data[$key]) ? $this->data[$key] : $default;
+        return $this->data[$key] ?? $default;
     }
 
-    public function set($key, $value, $ttl = null)
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
     {
         $this->data[$key] = $value;
+        return true;
     }
 
-    public function has($key)
+    public function has(string $key): bool
     {
         return isset($this->data[$key]);
     }
 
-    public function delete($key)
+    public function delete(string $key): bool
     {
-        // TODO: Implement delete() method.
+        unset($this->data[$key]);
+        return true;
     }
 
-    public function clear()
+    public function clear(): bool
     {
-        // TODO: Implement clear() method.
+        $this->data = [];
+        return true;
     }
 
-    public function getMultiple($keys, $default = null)
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
-        // TODO: Implement getMultiple() method.
+        $result = [];
+        foreach ($keys as $key) {
+            if (isset($this->data[$key])) {
+                $result[$key] = $this->data[$key];
+            }
+        }
+        return $result;
     }
 
-    public function setMultiple($values, $ttl = null)
+    /**
+     * @param iterable<string, mixed> $values
+     */
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
     {
-        // TODO: Implement setMultiple() method.
+        foreach ($values as $key => $value) {
+            $this->data[$key] = $value;
+        }
+        return true;
     }
 
-    public function deleteMultiple($keys)
+    public function deleteMultiple(iterable $keys): bool
     {
-        // TODO: Implement deleteMultiple() method.
+        foreach ($keys as $key) {
+            unset($this->data[$key]);
+        }
+        return true;
     }
 }

--- a/tests/Secret/SecretTest.php
+++ b/tests/Secret/SecretTest.php
@@ -10,7 +10,7 @@ class SecretTest extends TestCase
     /**
      * Tests that realistically, aren't going to fail.
      */
-    public function testBasicFunctionality()
+    public function testBasicFunctionality(): void
     {
         $secret = new Secret("ReynolmIndustries", "MrSmith", "SecretKey");
         $this->assertEquals("ReynolmIndustries", $secret->getIssuer());
@@ -18,7 +18,7 @@ class SecretTest extends TestCase
         $this->assertEquals("SecretKey", $secret->getSecretKey());
     }
 
-    public function testGetUri()
+    public function testGetUri(): void
     {
         $secret = new Secret("Example", "alice@google.com", "JBSWY3DPEHPK3PXP");
         $this->assertEquals("otpauth://totp/Example%3Aalice%40google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example", $secret->getUri());


### PR DESCRIPTION
- Support PHP 8.2
- Update all libs (endroid/qr-code, psr/cache, christian-riesen/base32, paragonie/random_compat)
- Add psr/simple-cache:^3.0
- Add CodeStyle fixer
- PhpStan level up to 8
- Add fast command with `Makeile` 
- Use Docker